### PR TITLE
修复 Prettier v3 format 为异步方法导致生成结果错误问题，锁定版本为 2.8.8

### DIFF
--- a/packages/ts-codegen-core/package.json
+++ b/packages/ts-codegen-core/package.json
@@ -22,7 +22,7 @@
     "axios": "0.21.x",
     "js-yaml": "4.0.x",
     "lodash": "4.17.x",
-    "prettier": "*"
+    "prettier": "2.8.8"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fix the issue of incorrect generation results caused by asynchronous methods in the Prettier v3 format, locking the Prettier version to 2.8.8